### PR TITLE
Add elasticsearch 7.9.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ltrVersion = 1.5.0
-elasticsearchVersion = 7.9.0
-luceneVersion = 8.6.0
+ltrVersion = 1.5.3
+elasticsearchVersion = 7.9.3
+luceneVersion = 8.6.2
 ow2Version = 7.2
 antlrVersion=4.5.1-1


### PR DESCRIPTION
We need to update to `7.9.3` because of memory leak error in lucene `8.6.0`.